### PR TITLE
Adiciona script de instalação rápida e abre navegador automaticamente no npm start

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ Boilerplate básico para projetos front-end com ênfase em HTML e CSS.
 
 Optamos por usar o [Parcel](https://pt.parceljs.org/), que é um bundler que atende ao objetivo do projeto, é rápido e não precisa de configuração. Então, o projeto tem suporte a [Sass](https://sass-lang.com/), suporte a JavaScript moderno com Babel e muitos mais.
 
+## Instalação rápida
+Execute no seu terminal o seguinte comando para começar rapidamente com o BFB:
+
+```sh
+$ sh -c "$(curl -sSL http://bit.ly/dpw-bfb-sh)"
+```
+
 ### Comandos
 
 | Comando         | O que faz?                   | Observação                     |

--- a/bfb.sh
+++ b/bfb.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+set -e
+
+# color vars
+reset="\033[0m"
+success="\033[32m"
+error="\033[31m"
+main="\033[34m"
+
+exists() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+step() {
+  echo "\n$main> $1$reset..."
+}
+
+check() {
+  echo "$success> ☑️  $1 $reset"
+}
+
+error () {
+  echo "$error> ❌ $1"
+  exit 0
+}
+
+step "Checking requirements"
+
+if ! exists git ; then
+  error "Git is not installed"
+else
+  check "Git is installed"
+fi
+
+if ! exists node ; then
+  error "NodeJS is not installed"
+else
+  check "NodeJS is installed"
+fi
+
+if [ ! -d basic-front-boilerplate ]; then
+  step "Installing BFB"
+  git clone https://github.com/desenvolvweb/basic-front-boilerplate
+  check
+fi
+
+cd basic-front-boilerplate
+
+step "Installing dependencies"
+npm install
+check
+
+step "Running BFB"
+npm run dev

--- a/bfb.sh
+++ b/bfb.sh
@@ -15,11 +15,11 @@ step() {
   echo "\n$main> $1$reset..."
 }
 
-check() {
+success() {
   echo "$success> ☑️  $1 $reset"
 }
 
-error () {
+error() {
   echo "$error> ❌ $1"
   exit 0
 }
@@ -29,26 +29,28 @@ step "Checking requirements"
 if ! exists git ; then
   error "Git is not installed"
 else
-  check "Git is installed"
+  success "Git is installed"
 fi
 
 if ! exists node ; then
   error "NodeJS is not installed"
 else
-  check "NodeJS is installed"
+  success "NodeJS is installed"
 fi
 
+step "Cloning BFB"
 if [ ! -d basic-front-boilerplate ]; then
-  step "Installing BFB"
   git clone https://github.com/desenvolvweb/basic-front-boilerplate
-  check
+  success
+else
+  success "BFB already cloned"
 fi
 
 cd basic-front-boilerplate
 
 step "Installing dependencies"
 npm install
-check
+success
 
 step "Running BFB"
 npm run dev

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "script.js",
   "scripts": {
     "start": "npm run dev",
-    "dev": "parcel index.html",
+    "dev": "parcel index.html --open",
     "build": "parcel build index.html"
   },
   "repository": {


### PR DESCRIPTION
A url curta foi gerada para o repo final, por isso não funcionará até que o pull request seja aceito.
Para validar o script, execute:

```sh
$ sh -c "$(curl -sSL https://raw.githubusercontent.com/verzola/basic-front-boilerplate/master/bfb.sh)"
```